### PR TITLE
Fix recon logging

### DIFF
--- a/modules/recon.py
+++ b/modules/recon.py
@@ -5,9 +5,9 @@ from modules.scanner import (
     run_subfinder,
     run_amass,
     run_httpx,
-    run_gau
+    run_gau,
+    write_json,
 )
-from modules.utils import write_json
 
 def run_full_recon(domain):
     print(f"[+] Starting recon on: {domain}")


### PR DESCRIPTION
## Summary
- import `write_json` from `modules.scanner`
- store recon results using the `(tool, domain, output)` format

## Testing
- `python -m py_compile modules/recon.py`
- `python -m py_compile modules/scanner.py`
- `pytest -q`
- `python - <<'PY'
from modules.recon import run_full_recon
run_full_recon('example.com')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6841f73c211c8325b3072428766f4a86