### PR TITLE
Fix recon JSON logging

### DIFF
--- a/modules/recon.py
+++ b/modules/recon.py
@@ -5,9 +5,9 @@ from modules.scanner import (
     run_subfinder,
     run_amass,
     run_httpx,
-    run_gau
+    run_gau,
+    write_json,
 )
-from modules.utils import write_json
 
 def run_full_recon(domain):
     print(f"[+] Starting recon on: {domain}")


### PR DESCRIPTION
## Summary
- use the `scanner.write_json` helper in `recon`

## Testing
- `python -m py_compile modules/recon.py modules/scanner.py modules/utils.py ai/openai_helper.py serve.py main.py report_generator.py`
- `python serve.py` *(fails: ModuleNotFoundError: No module named 'itsdangerous')*

------
https://chatgpt.com/codex/tasks/task_e_6841f60346fc8325ba15ec43d3d779a7