### PR TITLE
Fix static directory for FastAPI server

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -14,7 +14,10 @@ from modules.utils import load_scan_log, append_scan_log, update_scan_status
 
 app = FastAPI()
 app.add_middleware(SessionMiddleware, secret_key="secret123")
-app.mount("/static", StaticFiles(directory="static"), name="static")
+
+STATIC_DIR = Path("static")
+STATIC_DIR.mkdir(exist_ok=True)
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 SCAN_LOG_PATH = Path("data/scan_log.json")
 SCAN_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- ensure the `static` directory exists before mounting in `serve.py`

## Testing
- `pytest -q`
- `uvicorn serve:app --host 0.0.0.0 --port 8000`

------
https://chatgpt.com/codex/tasks/task_e_6841fee79004832595e7dd8c07c1c847